### PR TITLE
Fix: Refactor imports in useEuroCurrencyInput composable 

### DIFF
--- a/composables/useEuroCurrencyInput.ts
+++ b/composables/useEuroCurrencyInput.ts
@@ -1,4 +1,5 @@
-import { useCurrencyInput, type CurrencyInputOptions } from 'vue-currency-input'
+import type { CurrencyInputOptions } from 'vue-currency-input'
+import { useCurrencyInput } from 'vue-currency-input'
 
 export function useEuroCurrencyInput(customOptions?: Partial<CurrencyInputOptions>) {
   const defaultOptions: CurrencyInputOptions = {


### PR DESCRIPTION
Refactor imports in useEuroCurrencyInput composable to separate between regular and type-only import.