### PR TITLE
Enhancement: Add custom fetch api usable

### DIFF
--- a/app/components/form/book/Edit.vue
+++ b/app/components/form/book/Edit.vue
@@ -139,7 +139,7 @@ async function editBook(event: FormSubmitEvent<BookFields>) {
   loading.value = true
   form.value.clear() 
 
-  const editedBook = await $api<Book>('/books/' + props.initialBook.isbn, {
+  const editedBook = await $api<Book>(`/books/${props.initialBook.isbn}`, {
     method: 'PUT',
     body: event.data,
     onResponse: () => {

--- a/app/components/form/group/Book.vue
+++ b/app/components/form/group/Book.vue
@@ -117,7 +117,7 @@ async function submitBook(event: FormSubmitEvent<BookFields>) {
   loading.value = true
 
   const body = {...event.data}
-  if (body.exam_id === null) {
+  if (body.exam_id === null || body.exam_id === undefined) {
     delete body.exam_id
   }
 

--- a/app/components/form/group/Book.vue
+++ b/app/components/form/group/Book.vue
@@ -16,11 +16,15 @@
       <UInput v-model="state.publisher" type="text" placeholder="FVJus Verlag" class="w-full" />
     </UFormField>
 
-    <div class="inline-flex flex-row gap-x-2">
+    <UFormField label="Prüfung" name="exam_id">
+      <USelect v-model="state.exam_id" :items="exams" label-key="name" value-key="id" placeholder="Prüfung auswählen" class="w-full" />
+    </UFormField>
+
+    <div class="grid grid-cols-2 gap-x-4">
       <UFormField label="Auflage" name="edition" required>
-        <UInput v-model="state.edition" type="number" placeholder="14" class="w-full" />
+        <UInput v-model="state.edition" type="text" placeholder="14" class="w-full" />
       </UFormField>
-      
+
       <UFormField label="Max. Preis" name="maxPrice" required>
         <UInputNumber
           v-model="state.maxPrice"
@@ -36,10 +40,6 @@
         />
       </UFormField>
     </div>
-
-    <UFormField label="Prüfung" name="exam_id">
-      <USelect v-model="state.exam_id" :items="exams" label-key="name" value-key="id" class="w-full" placeholder="Prüfung auswählen" />
-    </UFormField>
 
     <div class="w-full mt-2 flex flex-row justify-end gap-x-2">
       <UButton color="primary" variant="outline" label="Zurücksetzen" @click="clearForm" />
@@ -71,14 +71,14 @@ const props = defineProps({
   }
 })
 
-const { token } = useAuth()
+const { $api } = useNuxtApp()
 const form = ref()
 const loading = ref<boolean>(false)
-const exams = ref<Exam[]>([])
+const exams = ref<Exam[]>([{ id: null, name: '-Keine Prüfung-' }])
 
-onMounted(fetchExams)
+fetchExams()
 
-const state = reactive<BookFields>({
+const initialState: BookFields = {
   isbn: '',
   title: '',
   authors: '',
@@ -86,7 +86,8 @@ const state = reactive<BookFields>({
   edition: undefined,
   maxPrice: undefined,
   exam_id: undefined,
-})
+}
+const state = reactive<BookFields>({ ...initialState })
 
 const validate = (state: BookFields): FormError[] => {
   const errors = []
@@ -96,7 +97,7 @@ const validate = (state: BookFields): FormError[] => {
   if (!state.authors) errors.push({ name: 'authors', message: 'Autor(en) sind verpflichtend' })
   if (!state.publisher) errors.push({ name: 'publisher', message: 'Verlag ist verpflichtend' })
   if (state.maxPrice == null) errors.push({ name: 'maxPrice', message: 'Max. Preis ist verpflichtend' })
-  //if (state.maxPrice && state.maxPrice <= 0) errors.push({ name: 'maxPrice', message: 'Max. Preis muss größer als 0 sein' })
+  if (state.maxPrice && state.maxPrice <= 0) errors.push({ name: 'maxPrice', message: 'Max. Preis muss größer als 0 sein' })
   if (!state.edition) errors.push({ name: 'edition', message: 'Auflage ist verpflichtend' })
   if (state.edition && state.edition <= 0) errors.push({ name: 'edition', message: 'Auflage muss größer als 0 sein' })
   return errors
@@ -116,71 +117,56 @@ async function submitBook(event: FormSubmitEvent<BookFields>) {
   loading.value = true
 
   const body = {...event.data}
-  if (body.exam_id === undefined) {
+  if (body.exam_id === null) {
     delete body.exam_id
   }
 
-  const response = await fetch(useRuntimeConfig().public.apiUrl + '/books', {
+  const createdBook = await $api<Book>('/books', {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `${token.value}`,
+    body: body,
+    onResponse: () => {
+      loading.value = false
     },
-    body: JSON.stringify(event.data),
-  })
-  loading.value = false
-  
-  if (response.ok) {
-    const book = await response.json()
-    useToast().add({
-      title: 'Erfolg',
-      description: 'Buch erfolgreich angelegt.',
-      icon: 'i-heroicons-check-circle',
-      color: 'success',
-    })
-
-    props.onSubmit(book)
-  } else {
-    const data = await response.json()
+    onResponseError: ({ response }) => {
+      const data = response._data
     
-    const errors = []
-    for (const field in data) {
-      if (data[field].length > 0) {
-        errors.push({
-          name: field,
-          message: data[field][0]
-        })
+      const errors = []
+      for (const field in data) {
+        if (data[field].length > 0) {
+          errors.push({
+            name: field,
+            message: data[field][0]
+          })
+        }
       }
+      form.value.setErrors(errors)
+
+      useToast().add({
+        title: 'Fehler',
+        description: 'Buch konnte nicht angelegt werden!',
+        icon: 'i-heroicons-exclamation-triangle',
+        color: 'error',
+      })
     }
-    form.value.setErrors(errors)
+  })
 
-    useToast().add({
-      title: 'Fehler',
-      description: 'Buch konnte nicht angelegt werden!',
-      icon: 'i-heroicons-exclamation-triangle',
-      color: 'error',
-    })
-  }
-}
+  useToast().add({
+    title: 'Erfolg',
+    description: 'Buch erfolgreich angelegt.',
+    icon: 'i-heroicons-check-circle',
+    color: 'success',
+  })
 
-const clearForm = () => {
-  state.isbn = ''
-  state.title = ''
-  state.authors = ''
-  state.maxPrice = undefined
-  state.edition = undefined
-  state.publisher = ''
-  state.exam_id = undefined
+  props.onSubmit(createdBook)
 }
 
 async function fetchExams() {
-  const response = await $fetch<Page<Exam>>(useRuntimeConfig().public.apiUrl + '/exams', {
-    headers: {
-      Authorization: `${token.value}`,
-    },
-  })
-  
-  exams.value.push({id: null, name: '-Keine Prüfung-'})
-  exams.value.push(...response.results)
+  const { data } = await useApiFetch<Page<Exam>>('/exams')
+  exams.value.push(...data.value?.results || [])
+}
+
+const clearForm = () => {
+  form.value.clear()
+  Object.assign(state, initialState)
 }
 </script>

--- a/app/components/form/group/Seller.vue
+++ b/app/components/form/group/Seller.vue
@@ -120,7 +120,7 @@ async function createSeller(event: FormSubmitEvent<SellerFields>) {
 
       useToast().add({
         title: 'Fehler',
-        description: 'Buch konnte nicht angelegt werden!',
+        description: 'Verkäufer:in konnte nicht angelegt werden!',
         icon: 'i-heroicons-exclamation-triangle',
         color: 'error',
       })

--- a/app/components/form/group/Seller.vue
+++ b/app/components/form/group/Seller.vue
@@ -57,7 +57,7 @@ const props = defineProps({
   }
 })
 
-const { token } = useAuth()
+const { $api } = useNuxtApp()
 const router = useRouter()
 const form = ref()
 const loading = ref<boolean>(false)
@@ -79,6 +79,7 @@ const validate = (state: SellerFields): FormError[] => {
   if (state.matriculationNumber && state.matriculationNumber.toString().length !== 8)
     errors.push({ name: 'matriculationNumber', message: 'Matrikelnummer muss genau 8 Ziffern haben' })
   if (!state.email) errors.push({ name: 'email', message: 'Email ist verpflichtend' })
+  if (state.email && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(state.email)) errors.push({ name: 'email', message: 'Email ist ungültig' })
   if (state.note && state.note.length > 255) errors.push({ name: 'note', message: 'Anmerkung darf maximal 255 Zeichen enthalten' })
   return errors
 }
@@ -97,48 +98,45 @@ async function createSeller(event: FormSubmitEvent<SellerFields>) {
   loading.value = true
   form.value.clear()
 
-  const response = await fetch(useRuntimeConfig().public.apiUrl + '/sellers', {
+  const response = await $api<Seller>('/sellers', {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `${token.value}`,
+    body: event.data,
+    onResponse: () => {
+      loading.value = false
     },
-    body: JSON.stringify(event.data),
-  })
-  loading.value = false
-  
-  if (response.ok) {
-    user.value = await response.json()
-    useToast().add({
-      title: 'Erfolg',
-      description: 'Verkäufer:in erfolgreich angelegt.',
-      icon: 'i-heroicons-check-circle',
-      color: 'success',
-    })
+    onResponseError: ({ response }) => {
+      const data = response._data
     
-    if (props.to) {
-      router.push(props.to)
-    }
-  } else {
-    const data = await response.json()
-    
-    const errors = []
-    for (const field in data) {
-      if (data[field].length > 0) {
-        errors.push({
-          name: field,
-          message: data[field][0]
-        })
+      const errors = []
+      for (const field in data) {
+        if (data[field].length > 0) {
+          errors.push({
+            name: field,
+            message: data[field][0]
+          })
+        }
       }
-    }
-    form.value.setErrors(errors)
+      form.value.setErrors(errors)
 
-    useToast().add({
-      title: 'Fehler',
-      description: 'Verkäufer:in konnte nicht angelegt werden!',
-      icon: 'i-heroicons-exclamation-triangle',
-      color: 'error',
-    })
+      useToast().add({
+        title: 'Fehler',
+        description: 'Buch konnte nicht angelegt werden!',
+        icon: 'i-heroicons-exclamation-triangle',
+        color: 'error',
+      })
+    }
+  })
+  
+  user.value = response
+  useToast().add({
+    title: 'Erfolg',
+    description: 'Verkäufer:in erfolgreich angelegt.',
+    icon: 'i-heroicons-check-circle',
+    color: 'success',
+  })
+  
+  if (props.to) {
+    router.push(props.to)
   }
 }
 </script>

--- a/app/components/form/group/step/Overview.vue
+++ b/app/components/form/group/step/Overview.vue
@@ -51,7 +51,7 @@ const props = defineProps({
 })
 
 const router = useRouter()
-const { token } = useAuth()
+const { $api } = useNuxtApp()
 
 const buttonLabel = computed(() => {
   return props.modelValue.offers.length === 1 ? 'Angebot anlegen' : 'Angebote anlegen'
@@ -67,35 +67,26 @@ const submitOffers = async () => {
     location: offer.location,
   }))
 
-  const response = await fetch(useRuntimeConfig().public.apiUrl + '/offers/bulk', {
+  await $api('/offers/bulk', {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `${token.value}`,
-    },
-    body: JSON.stringify(createOffers),
+    body: createOffers,
+    onResponseError: () => {
+      useToast().add({
+        title: 'Fehler',
+        description: 'Angebote konnten nicht angelegt werden.',
+        icon: 'i-heroicons-x-circle',
+        color: 'error',
+      })
+    }
   })
 
-  if (response.ok) {
-    useToast().add({
-      title: 'Erfolg',
-      description: 'Angebot erfolgreich angelegt.',
-      icon: 'i-heroicons-check-circle',
-      color: 'success',
-    })
-    
-    router.push('/fv/offers')
-  } else {
-    const data = await response.json()
-    console.error('No offers created', data)
-    
-    useToast().add({
-      title: 'Fehler',
-      description: data,
-      icon: 'i-heroicons-check-circle',
-      color: 'error',
-    })
-  }
+  useToast().add({
+    title: 'Erfolg',
+    description: 'Angebote erfolgreich angelegt.',
+    icon: 'i-heroicons-check-circle',
+    color: 'success',
+  })
+  router.push('/fv/offers')
 }
 
 interface CreateOffer {

--- a/app/components/form/group/step/Seller.vue
+++ b/app/components/form/group/step/Seller.vue
@@ -4,7 +4,7 @@
       <USelectMenu
         v-model="selected"
         v-model:search-term="searchTerm"
-        :items="sellers || []"
+        :items="sellersPage?.results || []"
         :search-input="{
           placeholder: 'Suche nach Verkäufer:in...',
           icon: 'i-lucide-search',
@@ -64,7 +64,6 @@ const props = defineProps({
 })
 
 const selected = ref<Seller>(props.currentSeller)
-const { token } = useAuth()
 
 // This anonymous function is called by the USelectMenu component to pass the selected seller to the parent component
 const handleSearchSubmit = () => {
@@ -84,14 +83,8 @@ const fetchParams = computed(() => ({
   limit: 20,
 }))
 
-const { data: sellers, status } = await useFetch(useRuntimeConfig().public.apiUrl + '/sellers', {
-  headers: {
-    Authorization: `${token.value}`,
-  },
+const { data: sellersPage, status } = await useApiFetch<Page<Seller>>('/sellers', {
   params: fetchParams,
-  transform: (data: Page<Seller>) => {
-    return data.results as Seller[]
-  },
   lazy: true,
   watch: [searchTermDebounced],
 })

--- a/app/components/search/filter/Exam.vue
+++ b/app/components/search/filter/Exam.vue
@@ -60,7 +60,6 @@ const props = defineProps({
 })
 const emit = defineEmits(['update:examFilter'])
 
-const { token } = useAuth()
 const popoverOpen = ref<boolean>(false)
 const localExamFilter = ref<Filter<ExamFilter>>(props.examFilter)
 
@@ -70,11 +69,7 @@ const state = reactive({
 })
 
 onMounted(async () => {
-  const { data: examsPage } = await useFetch<Page<Exam>>(useRuntimeConfig().public.apiUrl + '/exams', {
-    headers: {
-      Authorization: `${token.value}`,
-    },
-  })
+  const { data: examsPage } = await useApiFetch<Page<Exam>>('/exams')
 
   exams.push(...(examsPage.value?.results.map((exam) => exam.name) ?? []))
   

--- a/app/composables/useApiFetch.ts
+++ b/app/composables/useApiFetch.ts
@@ -1,0 +1,11 @@
+import type { UseFetchOptions } from 'nuxt/app'
+
+export function useApiFetch<T>(
+  url: string | (() => string),
+  options?: UseFetchOptions<T>,
+) {
+  return useFetch(url, {
+    ...options,
+    $fetch: useNuxtApp().$api as typeof $fetch
+  })
+}

--- a/app/pages/fv/books/[isbn].vue
+++ b/app/pages/fv/books/[isbn].vue
@@ -206,6 +206,7 @@ definePageMeta({
   }
 })
 
+const { $api } = useNuxtApp()
 const UIcon = resolveComponent('UIcon')
 const table = useTemplateRef('table')
 const columns: TableColumn<Offer>[] = [
@@ -293,7 +294,6 @@ const timelineItems = [
     icon: 'i-lucide-git-merge',
   }
 ] satisfies TimelineItem[]
-const { token } = useAuth()
 const route = useRoute()
 const router = useRouter()
 const editHistoryModal = ref<boolean>(false)
@@ -342,13 +342,9 @@ const onEditSeller = async () => {
 }
 
 async function fetchPriceBins(isbn: string) {
-  await $fetch(useRuntimeConfig().public.apiUrl + `/books/${isbn}/price-bins`, {
-    headers: {
-      Authorization: `${token.value}`,
-    },
-  })
+  await $api<BookPriceBins>(`/books/${isbn}/price-bins`)
   .then((res) => {
-    bookPriceBins.value = res as BookPriceBins
+    bookPriceBins.value = res
   })
   .catch((error) => {
     console.error('Error while fetching price bins', error)

--- a/app/pages/fv/books/[isbn].vue
+++ b/app/pages/fv/books/[isbn].vue
@@ -316,10 +316,7 @@ const fetchParams = computed(() => ({
   book__isbn: route.params.isbn,
 }))
 
-const { data: book, refresh: refreshSellerData } = useFetch<Book>(useRuntimeConfig().public.apiUrl + '/books/' + route.params.isbn, {
-  headers: {
-    Authorization: `${token.value}`,
-  },
+const { data: book, refresh: refreshSellerData } = useApiFetch<Book>('/books/' + route.params.isbn, {
   onResponseError: () => {
     // Try to go back to the previous page
     if (window.history.length > 1) {
@@ -331,10 +328,7 @@ const { data: book, refresh: refreshSellerData } = useFetch<Book>(useRuntimeConf
   },
 })
 
-const { data: offers, pending: loadingOffers } = useFetch<Page<Offer>>(useRuntimeConfig().public.apiUrl + '/offers', {
-  headers: {
-    Authorization: `${token.value}`,
-  },
+const { data: offers, pending: loadingOffers } = useApiFetch<Page<Offer>>('/offers', {
   params: fetchParams,
 })
 

--- a/app/pages/fv/books/index.vue
+++ b/app/pages/fv/books/index.vue
@@ -145,7 +145,6 @@ const columns: TableColumn<Book>[] = [
     enableHiding: false,
   }
 ]
-const { token } = useAuth()
 const currentPage = ref<number>(1)
 const pageSizes = [5, 10, 20, 50]
 const itemsPerPage = ref<number>(pageSizes[1] ?? 10)
@@ -160,10 +159,7 @@ const fetchParams = computed(() => ({
 const columnVisibility = ref({
 })
 
-const { data, pending } = useFetch<Page<Book>>(useRuntimeConfig().public.apiUrl + '/books', {
-  headers: {
-    Authorization: `${token.value}`,
-  },
+const { data, pending } = useApiFetch<Page<Book>>('/books', {
   params: fetchParams,
 })
 </script>

--- a/app/pages/fv/offers/index.vue
+++ b/app/pages/fv/offers/index.vue
@@ -219,7 +219,6 @@ const columns: TableColumn<Offer>[] = [
     enableHiding: false,
   }
 ]
-const { token } = useAuth()
 const currentPage = ref<number>(1)
 const pageSizes = [5, 10, 20, 50]
 const itemsPerPage = ref<number>(pageSizes[1] ?? 10)
@@ -236,11 +235,8 @@ const columnVisibility = ref({
   createdAt: false,
 })
 
-const { data, pending } = useFetch<Page<Offer>>(useRuntimeConfig().public.apiUrl + '/offers', {
+const { data, pending } = useApiFetch<Page<Offer>>('/offers', {
   key: 'offers',
-  headers: {
-    Authorization: `${token.value}`,
-  },
   params: fetchParams,
 })
 

--- a/app/pages/fv/search.vue
+++ b/app/pages/fv/search.vue
@@ -78,7 +78,6 @@ onMounted(() => {
   search()
 })
 
-const { token } = useAuth()
 const currentPage = ref<number>(1)
 const itemsPerPage = ref<number>(10)
 const filter = ref({
@@ -117,11 +116,8 @@ const fetchParams = computed(() => ({
   active: filter.value.active.active ? undefined : 'true',
 }))
 
-const { data: offerResults, refresh } = useFetch<Page<Offer>>(useRuntimeConfig().public.apiUrl + '/offers', {
+const { data: offerResults, refresh } = useApiFetch<Page<Offer>>('/offers', {
   params: fetchParams,
-  headers: {
-    Authorization: `${token.value}`,
-  },
   onResponse: async () => {
     await navigateTo({
       path: '/fv/search',

--- a/app/pages/fv/sellers/[id].vue
+++ b/app/pages/fv/sellers/[id].vue
@@ -226,7 +226,6 @@ const columns: TableColumn<Offer>[] = [
     cell: ({ row }) => h('div', { class: 'text-right' }, formatPrice(row.original.price)),
   },
 ]
-const { token } = useAuth()
 const route = useRoute()
 const router = useRouter()
 const editHistoryModal = ref<boolean>(false)
@@ -248,19 +247,13 @@ const fetchParams = computed(() => ({
   seller: route.params.id,
 }))
 
-const { data: seller, refresh: refreshSellerData } = useFetch<Seller>(useRuntimeConfig().public.apiUrl + '/sellers/' + route.params.id, {
-  headers: {
-    Authorization: `${token.value}`,
-  },
+const { data: seller, refresh: refreshSellerData } = useApiFetch<Seller>('/sellers/' + route.params.id, {
   onResponseError: () => {
     router.push('/fv/sellers')
   },
 })
 
-const { data: sellerOffers, pending: loadingSellerOffers } = useFetch<Page<Offer>>(useRuntimeConfig().public.apiUrl + '/offers', {
-  headers: {
-    Authorization: `${token.value}`,
-  },
+const { data: sellerOffers, pending: loadingSellerOffers } = useApiFetch<Page<Offer>>('/offers', {
   params: fetchParams,
 })
 

--- a/app/pages/fv/sellers/index.vue
+++ b/app/pages/fv/sellers/index.vue
@@ -65,7 +65,6 @@ definePageMeta({
   layout: 'protected',
 })
 
-const { token } = useAuth()
 const currentPage = ref<number>(1)
 const pageSizes = [5, 10, 20, 50]
 const itemsPerPage = ref<number>(pageSizes[1] ?? 10)
@@ -85,10 +84,7 @@ const fetchParams = computed(() => ({
   search: searchInput.value,
 }))
 
-const { data, pending, refresh } = useFetch<Page<Seller>>(useRuntimeConfig().public.apiUrl + '/sellers', {
-  headers: {
-    Authorization: `${token.value}`,
-  },
+const { data, pending, refresh } = useApiFetch<Page<Seller>>('/sellers', {
   params: fetchParams,
 })
 

--- a/app/plugins/api.ts
+++ b/app/plugins/api.ts
@@ -1,0 +1,29 @@
+export default defineNuxtPlugin((nuxtApp) => {
+  const { token, signOut } = useAuth()
+
+  const api = $fetch.create({
+    baseURL: useRuntimeConfig().public.apiUrl,
+    onRequest({ request: _request, options, error: _error }) {
+      if (token.value) {
+        options.headers.set('Authorization', `${token.value}`)
+      }
+    },
+    async onResponseError({ response }) {
+      if (response.status === 401) {
+        await nuxtApp.runWithContext(() => useToast().add({
+          title: 'Sitzung beendet',
+          description: 'Die aktuelle Sitzung ist abgelaufen, neu einloggen um weiterzumachen.',
+          icon: 'i-lucide-log-out',
+          color: 'info',
+        }))
+        await nuxtApp.runWithContext(() => signOut({ callbackUrl: '/login' }))
+      }
+    }
+  })
+
+  return {
+    provide: {
+      api
+    }
+  }
+})

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -54,6 +54,7 @@ export default defineNuxtConfig({
       endpoints: {
         signIn: { path: '/login', method: 'post' },
         getSession: { path: '/user', method: 'get' },
+        signOut: false,
       },
       session: {
         dataType: {


### PR DESCRIPTION
Adds a more central approach to data fetching by creating a custom wrapper around `$fetch` (which itself wraps [unjs/ofetch](https://github.com/unjs/ofetch) within nuxt itself. Furthermore, besides the custom plugin, a usable `useApiFetch` was introduced which wraps `useFetch` with the custom logic by the `$api` plugin.

This tries to achieve a better solution as aimed in #39.  